### PR TITLE
Correction - QueueHandle_t defination in PCNT example.

### DIFF
--- a/examples/peripherals/pcnt/main/pcnt_example_main.c
+++ b/examples/peripherals/pcnt/main/pcnt_example_main.c
@@ -53,7 +53,7 @@
 #define PCNT_INPUT_CTRL_IO  5  // Control GPIO HIGH=count up, LOW=count down
 #define LEDC_OUTPUT_IO      18 // Output GPIO of a sample 1 Hz pulse generator
 
-xQueueHandle pcnt_evt_queue;   // A queue to handle pulse counter events
+QueueHandle_t pcnt_evt_queue;   // A queue to handle pulse counter events
 
 /* A sample structure to pass events from the PCNT
  * interrupt handler to the main program.


### PR DESCRIPTION
"xQueueHandle" raises an error.


"QueueHandle_t" works and compiles for IDF.